### PR TITLE
Add all available gradients into packed array

### DIFF
--- a/tests/test_target_gradients.py
+++ b/tests/test_target_gradients.py
@@ -5,6 +5,7 @@ from cctbx.array_family import flex
 import mmtbx.f_model
 
 from pydiscamb import DiscambWrapper
+from pydiscamb._cpp_module import TargetDerivatives
 
 
 class TestTargetGradients:
@@ -96,7 +97,6 @@ class TestTargetGradients:
 
         # Set up model
         random_structure.shake_sites_in_place(rms_difference=0.1)
-        scatterers = random_structure.scatterers()
         model = mmtbx.f_model.manager(f_obs=f_obs, xray_structure=random_structure)
         model.sfg_params.algorithm = "direct"
         target = model.target_functor()(compute_gradients=True)
@@ -111,3 +111,63 @@ class TestTargetGradients:
         with pytest.raises(AssertionError):
             # Supply incorrect length list
             w.d_target_d_params(list(d_target_d_fcalc.data())[1:])
+
+    def test_result_type(self, tyrosine):
+
+        f_obs = abs(tyrosine.structure_factors(d_min=2).f_calc())
+        model = mmtbx.f_model.manager(f_obs=f_obs, xray_structure=tyrosine)
+        target = model.target_functor()(compute_gradients=True)
+        d_target_d_f_calc = target.d_target_d_f_calc_work()
+
+        iselection = flex.bool(tyrosine.scatterers().size(), True).iselection()
+        tyrosine.scatterers().flags_set_grads(state=False)
+        tyrosine.scatterers().flags_set_grad_site(iselection)
+
+        w = DiscambWrapper(tyrosine)
+        assert isinstance(w.d_target_d_params(d_target_d_f_calc), flex.double)
+        assert isinstance(w.d_target_d_params(list(d_target_d_f_calc.data())), list)
+        assert isinstance(
+            w.d_target_d_params(list(d_target_d_f_calc.data()))[0], TargetDerivatives
+        )
+
+    def test_no_flags(self, tyrosine):
+
+        f_obs = abs(tyrosine.structure_factors(d_min=2).f_calc())
+        model = mmtbx.f_model.manager(f_obs=f_obs, xray_structure=tyrosine)
+        target = model.target_functor()(compute_gradients=True)
+        d_target_d_f_calc = target.d_target_d_f_calc_work()
+
+        w = DiscambWrapper(tyrosine)
+        res = w.d_target_d_params(d_target_d_f_calc)
+        assert res.size() == 0
+
+    @pytest.mark.slow
+    def test_multiple_flags(self, lysozyme):
+        lysozyme.scatterers().convert_to_anisotropic(lysozyme.unit_cell())
+        f_obs = abs(lysozyme.structure_factors(d_min=1).f_calc())
+        
+        lysozyme.shake_sites_in_place(rms_difference=0.1)
+        lysozyme.shake_adp()
+        lysozyme.shake_occupancies()
+
+
+        iselection = flex.bool(lysozyme.scatterers().size(), True).iselection()
+        lysozyme.scatterers().flags_set_grads(state=False)
+        lysozyme.scatterers().flags_set_grad_site(iselection)
+        lysozyme.scatterers().flags_set_grad_occupancy(iselection)
+        lysozyme.scatterers().flags_set_grad_u_aniso(iselection)
+
+        model = mmtbx.f_model.manager(f_obs=f_obs, xray_structure=lysozyme)
+        model.sfg_params.algorithm = "direct"
+        target = model.target_functor()(compute_gradients=True)
+        d_target_d_f_calc = target.d_target_d_f_calc_work()
+
+        w = DiscambWrapper(lysozyme)
+        res = w.d_target_d_params(d_target_d_f_calc)
+
+        # x, y, z, U11, U22, U33, U12, U13, U23, occupancy = 10
+        assert res.size() == lysozyme.scatterers().size() * 10
+
+        # Compare with cctbx
+        exp = target.gradients_wrt_atomic_parameters().packed()
+        assert pytest.approx(list(res), abs=1e-6, rel=1e-5) == list(exp)

--- a/tests/test_target_gradients.py
+++ b/tests/test_target_gradients.py
@@ -145,11 +145,10 @@ class TestTargetGradients:
     def test_correctness_all_flags(self, lysozyme):
         lysozyme.scatterers().convert_to_anisotropic(lysozyme.unit_cell())
         f_obs = abs(lysozyme.structure_factors(d_min=1).f_calc())
-        
+
         lysozyme.shake_sites_in_place(rms_difference=0.1)
         lysozyme.shake_adp()
         lysozyme.shake_occupancies()
-
 
         iselection = flex.bool(lysozyme.scatterers().size(), True).iselection()
         lysozyme.scatterers().flags_set_grads(state=False)
@@ -177,13 +176,16 @@ class TestTargetGradients:
         xrs = lysozyme
 
         import random
+
         random.seed(0)
-        selection = flex.bool([random.randint(0, 1) for _ in range(xrs.scatterers().size())])
+        selection = flex.bool(
+            [random.randint(0, 1) for _ in range(xrs.scatterers().size())]
+        )
         iselection = selection.iselection()
 
         xrs.convert_to_anisotropic(selection)
         f_obs = abs(xrs.structure_factors(d_min=2).f_calc())
-        
+
         xrs.shake_sites_in_place(rms_difference=0.1)
         xrs.shake_adp()
         xrs.shake_occupancies()
@@ -192,9 +194,13 @@ class TestTargetGradients:
         xrs.scatterers().flags_set_grad_u_aniso(iselection)
         iselection = flex.bool([not i for i in list(selection)]).iselection()
         xrs.scatterers().flags_set_grad_u_iso(iselection)
-        iselection = flex.bool([random.randint(0, 1) for _ in range(xrs.scatterers().size())]).iselection()
+        iselection = flex.bool(
+            [random.randint(0, 1) for _ in range(xrs.scatterers().size())]
+        ).iselection()
         xrs.scatterers().flags_set_grad_site(iselection)
-        iselection = flex.bool([random.randint(0, 1) for _ in range(xrs.scatterers().size())]).iselection()
+        iselection = flex.bool(
+            [random.randint(0, 1) for _ in range(xrs.scatterers().size())]
+        ).iselection()
         xrs.scatterers().flags_set_grad_occupancy(iselection)
 
         model = mmtbx.f_model.manager(f_obs=f_obs, xray_structure=xrs)

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -124,35 +124,6 @@ def test_f_calc_type(tyrosine):
     assert isinstance(w.f_calc(fc_c), miller.array)
 
 
-def test_d_target_d_f_calc_type(tyrosine):
-    from pydiscamb import DiscambWrapper
-
-    f_obs = abs(tyrosine.structure_factors(d_min=2).f_calc())
-    model = f_model.manager(f_obs=f_obs, xray_structure=tyrosine)
-    target = model.target_functor()(compute_gradients=True)
-    d_target_d_f_calc = target.d_target_d_f_calc_work()
-    xray.set_scatterer_grad_flags(
-        scatterers=tyrosine.scatterers(),
-        site=True,
-    )
-
-    w = DiscambWrapper(tyrosine)
-    assert isinstance(w.d_target_d_params(d_target_d_f_calc), flex.double)
-
-
-def test_d_target_d_f_calc_raise_when_no_flags(tyrosine):
-    from pydiscamb import DiscambWrapper
-
-    f_obs = abs(tyrosine.structure_factors(d_min=2).f_calc())
-    model = f_model.manager(f_obs=f_obs, xray_structure=tyrosine)
-    target = model.target_functor()(compute_gradients=True)
-    d_target_d_f_calc = target.d_target_d_f_calc_work()
-
-    w = DiscambWrapper(tyrosine)
-    with pytest.raises(ValueError, match="Gradient flags not supported"):
-        w.d_target_d_params(d_target_d_f_calc)
-
-
 @pytest.mark.parametrize("taam", [True, False])
 def test_default_init_with_kwargs(tyrosine, taam):
     from pydiscamb import DiscambWrapper, FCalcMethod


### PR DESCRIPTION
Also adds test to confirm the output is the same as cctbx's, using lysozyme (pdb 1JKB) at 1Å resolution. xyz, anisotropic ADPs, and occupancies all in the same array, all compare equal within absolute tolerance of 1e-6, relative tolerance of 1e-5