### PR TITLE
Fix adp parameter convention

### DIFF
--- a/pydiscamb/discamb_wrapper.py
+++ b/pydiscamb/discamb_wrapper.py
@@ -227,7 +227,7 @@ class DiscambWrapper(PythonInterface):
             size += 1 * s.grad_u_iso()
             size += 6 * s.grad_u_aniso()
             size += 1 * s.grad_occupancy()
-        out = flex.double(size)
+        out = flex.double(size, 0)
         o_ind = 0
         for s_ind, s in enumerate(self._scatterer_flags):
             if s.grad_site():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydiscamb"
-version = "0.1.0"
+version = "0.1.1"
 description="A python wrapper for DiSCaMB"
 readme = "README.md"
 authors = [

--- a/src/DiscambStructureFactorCalculator.cpp
+++ b/src/DiscambStructureFactorCalculator.cpp
@@ -122,4 +122,5 @@ void DiscambStructureFactorCalculator::update_calculator(){
     // mCalculator->update(mCrystal.atoms); // Already handled since we pass atoms to calculations
     assert(mAnomalous.size() == mCrystal.atoms.size());
     mCalculator->setAnomalous(mAnomalous);
+    mConverter.set(mCrystal.unitCell);
 }

--- a/src/read_structure.cpp
+++ b/src/read_structure.cpp
@@ -33,13 +33,7 @@ Crystal crystal_from_xray_structure(const py::object structure){
     crystal.atoms.assign(num_atoms, AtomInCrystal());
 
     crystal.xyzCoordinateSystem = structural_parameters_convention::XyzCoordinateSystem::fractional;
-    // Assume all adps use the same convention
-    if (structure.attr("use_u_iso")().attr("__getitem__")(0).cast<bool>()){
-        crystal.adpConvention = structural_parameters_convention::AdpConvention::U_cif;
-    }
-    else{
-        crystal.adpConvention = structural_parameters_convention::AdpConvention::U_star;
-    }
+    crystal.adpConvention = structural_parameters_convention::AdpConvention::U_star;
 
     // Set atoms
     update_crystal_from_xray_structure(crystal, structure);


### PR DESCRIPTION
Was read from 1st scatterer, but we only read u_iso or u_star, so it is always u_star for anisotropic (which is the only use of the parameter convention). If the 1st scatterer was iso, then this would produce wrong results