### PR TITLE
Add cache to speed up TAAM

### DIFF
--- a/include/DiscambStructureFactorCalculator.hpp
+++ b/include/DiscambStructureFactorCalculator.hpp
@@ -39,10 +39,11 @@ class DiscambStructureFactorCalculator {
         
         std::vector<discamb::Vector3i> hkl;
 
+        discamb::Crystal crystal;
+        std::vector<std::complex<double>> anomalous;
+
     private:
         discamb::SfCalculator *mCalculator;
-        discamb::Crystal mCrystal;
-        std::vector<std::complex<double>> mAnomalous;
         discamb::StructuralParametersConverter mConverter;
         void update_calculator();
 };

--- a/include/PythonInterface.hpp
+++ b/include/PythonInterface.hpp
@@ -25,6 +25,7 @@ class PythonInterface : public DiscambStructureFactorCalculator{
 
         void set_indices(py::object indices);
         void set_d_min(const double d_min);
+        void update_structure(py::object structure);
 
     private:
         py::object mStructure;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydiscamb"
-version = "0.1.2"
+version = "0.1.3"
 description="A python wrapper for DiSCaMB"
 readme = "README.md"
 authors = [

--- a/src/DiscambStructureFactorCalculator.cpp
+++ b/src/DiscambStructureFactorCalculator.cpp
@@ -28,13 +28,13 @@ DiscambStructureFactorCalculator::DiscambStructureFactorCalculator(
     vector<complex<double>> anomalous
 ) : 
     mCalculator(SfCalculator::create(crystal, calculator_parameters)), 
-    mCrystal(crystal), 
-    mAnomalous(anomalous),
-    mConverter(mCrystal.unitCell)
+    crystal(crystal), 
+    anomalous(anomalous),
+    mConverter(crystal.unitCell)
 {
-    assert(mCrystal.atoms.size() > 0);
-    assert(mAnomalous.size() > 0);
-    assert(mCrystal.atoms.size() == mAnomalous.size());
+    assert(crystal.atoms.size() > 0);
+    assert(anomalous.size() > 0);
+    assert(crystal.atoms.size() == anomalous.size());
     update_calculator();
 }
 
@@ -42,8 +42,8 @@ vector<complex<double>> DiscambStructureFactorCalculator::f_calc(){
     update_calculator();
     vector<complex<double>> sf;
     sf.resize(hkl.size());
-    vector<bool> count_atom_contribution (mCrystal.atoms.size(), true);
-    mCalculator->calculateStructureFactors(mCrystal.atoms, hkl, sf, count_atom_contribution);
+    vector<bool> count_atom_contribution (crystal.atoms.size(), true);
+    mCalculator->calculateStructureFactors(crystal.atoms, hkl, sf, count_atom_contribution);
     return sf;
 }
 
@@ -61,7 +61,7 @@ FCalcDerivatives DiscambStructureFactorCalculator::d_f_calc_hkl_d_params(int h, 
     update_calculator();
     FCalcDerivatives out;
     out.hkl = {h, k, l};
-    vector<bool> count_atom_contribution (mCrystal.atoms.size(), true);
+    vector<bool> count_atom_contribution (crystal.atoms.size(), true);
     mCalculator->calculateStructureFactorsAndDerivatives(
             out.hkl,
             out.structure_factor,
@@ -76,11 +76,11 @@ vector<TargetFunctionAtomicParamDerivatives> DiscambStructureFactorCalculator::d
     assert(hkl.size() == d_target_d_f_calc.size());
     vector<complex<double>> sf;
     vector<TargetFunctionAtomicParamDerivatives> out;
-    out.resize(mCrystal.atoms.size());
-    vector<bool> count_atom_contribution( mCrystal.atoms.size(), true );
+    out.resize(crystal.atoms.size());
+    vector<bool> count_atom_contribution( crystal.atoms.size(), true );
 
     mCalculator->calculateStructureFactorsAndDerivatives(
-        mCrystal.atoms,
+        crystal.atoms,
         hkl,
         sf,
         out,
@@ -89,8 +89,8 @@ vector<TargetFunctionAtomicParamDerivatives> DiscambStructureFactorCalculator::d
     );
 
     // Ensure correct convention (U_cart and Cartesian)
-    structural_parameters_convention::AdpConvention ac = mCrystal.adpConvention;
-    structural_parameters_convention::XyzCoordinateSystem xyzc = mCrystal.xyzCoordinateSystem;
+    structural_parameters_convention::AdpConvention ac = crystal.adpConvention;
+    structural_parameters_convention::XyzCoordinateSystem xyzc = crystal.xyzCoordinateSystem;
 
     int idx, nAtoms = out.size();
     vector<complex<double> > adpIn(6), adpOut(6);
@@ -119,8 +119,8 @@ vector<TargetFunctionAtomicParamDerivatives> DiscambStructureFactorCalculator::d
 }
 
 void DiscambStructureFactorCalculator::update_calculator(){
-    // mCalculator->update(mCrystal.atoms); // Already handled since we pass atoms to calculations
-    assert(mAnomalous.size() == mCrystal.atoms.size());
-    mCalculator->setAnomalous(mAnomalous);
-    mConverter.set(mCrystal.unitCell);
+    // mCalculator->update(crystal.atoms); // Already handled since we pass atoms to calculations
+    assert(anomalous.size() == crystal.atoms.size());
+    mCalculator->setAnomalous(anomalous);
+    mConverter.set(crystal.unitCell);
 }

--- a/src/PythonInterface.cpp
+++ b/src/PythonInterface.cpp
@@ -37,3 +37,10 @@ void PythonInterface::set_d_min(const double d_min){
 
     set_indices(miller_py.attr("indices")());
 }
+
+void PythonInterface::update_structure(py::object structure){
+    update_crystal_from_xray_structure(crystal, structure);
+    update_anomalous_from_xray_structure(anomalous, structure);
+    // DiscambStructureFactorCalculator::update_calculator is called before all relevant operations
+    // ensuring the updates here are handled
+}

--- a/src/python_module.cpp
+++ b/src/python_module.cpp
@@ -104,6 +104,12 @@ PYBIND11_MODULE(_cpp_module, m) {
             R"pbdoc(Set minimum d-spacing for calculating f_calc)pbdoc",
             py::arg("d_min")
         )
+        .def(
+            "update_structure",
+            &PythonInterface::update_structure,
+            R"pbdoc(Update atoms read from the given structure)pbdoc",
+            py::arg("structure")
+        )
         .def_property_readonly(
             "hkl",
             [](const PythonInterface &i)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,13 @@ import pytest
 
 from cctbx.xray import structure
 
+# Hack to clear the cache between tests
+@pytest.fixture(autouse=True)
+def clear_cache():
+    from pydiscamb import DiscambWrapper
+
+    DiscambWrapper._DiscambWrapper__clear_cache()
+
 
 @pytest.fixture
 def random_structure() -> structure:


### PR DESCRIPTION
Closes #14 

Adds a cache which returns a previously initialized DiscambWrapper object if all atom labels are equal in the same order, and the json passed to C++ is the same. 

With TAAM, lookup takes around 2ms, assignment with e.g. triclinic lyozyme takes around 20s on my machine.