### PR TITLE
Refactor caching, is now optional

### DIFF
--- a/doc/usage.ipynb
+++ b/doc/usage.ipynb
@@ -307,6 +307,71 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Note that atom type assignment can be slow for large structures. During refinement ect., where the same structure is used multiple times with only positions ect. change, one can update existing wrapper objects:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wrapper_1 = pydiscamb.DiscambWrapper(xrs, method=pydiscamb.FCalcMethod.TAAM)\n",
+    "xrs.shake_sites_in_place(0.1)\n",
+    "wrapper_2 = pydiscamb.DiscambWrapper(xrs, method=pydiscamb.FCalcMethod.TAAM)\n",
+    "\n",
+    "# Fcalc are different for the two wrapper objects\n",
+    "assert any(fc1 != fc2 for fc1, fc2 in zip(wrapper_1.f_calc(3), wrapper_2.f_calc(3)))\n",
+    "\n",
+    "wrapper_1.update_structure(xrs)\n",
+    "\n",
+    "# Fcalc are now all the same\n",
+    "assert all(fc1 == fc2 for fc1, fc2 in zip(wrapper_1.f_calc(3), wrapper_2.f_calc(3)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Another option for this is to make use of cached instances, in case existing objects are unavailable in the current scope. This is implemented in a specialized wrapper class:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pydiscamb.discamb_wrapper import DiscambWrapperCached\n",
+    "\n",
+    "# Wrapper objects created in a function scope will not persist outside\n",
+    "# Use this to show that these are all the same object\n",
+    "def init_wrapper():\n",
+    "    w = DiscambWrapperCached(xrs) # Can also be TAAM\n",
+    "    return id(w)\n",
+    "\n",
+    "try:\n",
+    "    print(w)\n",
+    "except NameError:\n",
+    "    # The wrapper object does not exist in this scope\n",
+    "    pass\n",
+    "\n",
+    "wrapper_ids = [\n",
+    "    init_wrapper(),\n",
+    "    init_wrapper(),\n",
+    "    init_wrapper(),\n",
+    "    init_wrapper(),\n",
+    "]\n",
+    "\n",
+    "# The objects all have the same ID; they are the same object,\n",
+    "# even when only existing inside the function scope\n",
+    "assert all(wi == init_wrapper() for wi in wrapper_ids)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# Structure factor gradients\n",
     "For refinement purposes, DiSCaMB's gradient calculations are exposed"
    ]
@@ -403,7 +468,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "phenix-2.0rc1-5592",
+   "display_name": "phenix-2.0rc1-5617",
    "language": "python",
    "name": "python3"
   },

--- a/pydiscamb/__init__.py
+++ b/pydiscamb/__init__.py
@@ -1,19 +1,13 @@
-from ._cpp_module import (
-    __doc__,
-    get_discamb_version,
-    get_table,
-    wrapper_tests,
-)
-from .taam_parameters import get_TAAM_databanks
+from ._cpp_module import __doc__, get_discamb_version, get_table, wrapper_tests
 from .discamb_wrapper import (
     DiscambWrapper,
     FCalcMethod,
     calculate_structure_factors_IAM,
     calculate_structure_factors_TAAM,
 )
+from .taam_parameters import get_TAAM_databanks
 
 __all__ = [
-    "__doc__",
     "get_discamb_version",
     "calculate_structure_factors_IAM",
     "calculate_structure_factors_TAAM",

--- a/pydiscamb/discamb_wrapper.py
+++ b/pydiscamb/discamb_wrapper.py
@@ -35,7 +35,7 @@ class DiscambWrapper(PythonInterface):
         Any kwargs present will override the defaults.
         The defaults are e.g. inferring the scattering table from `xrs`,
         and using the default TAAM databank.
-        See :code:`DiscambWrapper_Uncached._prepare_calculator_params` for details.
+        See :code:`DiscambWrapper._prepare_calculator_params` for details.
 
         Parameters
         ----------

--- a/pydiscamb/discamb_wrapper.py
+++ b/pydiscamb/discamb_wrapper.py
@@ -1,14 +1,13 @@
-from typing import overload, Tuple, Dict, Any, List, Union
 from enum import Enum
 from pathlib import Path
+from typing import Any, Dict, List, Tuple, Union, overload
 
-from cctbx.xray.structure import structure
-from cctbx.array_family import flex
 from cctbx import miller
-
+from cctbx.array_family import flex
+from cctbx.xray.structure import structure
 from pydiscamb._cpp_module import (
-    PythonInterface,
     FCalcDerivatives,
+    PythonInterface,
     TargetDerivatives,
     table_alias,
 )
@@ -176,8 +175,8 @@ class DiscambWrapper(PythonInterface):
 
     @classmethod
     def _from_pdb_str(cls, pdb_str: str, method, **kwargs) -> "DiscambWrapper":
-        import mmtbx.model
         import iotbx.pdb
+        import mmtbx.model
         from libtbx.utils import null_out
 
         pdb_inp = iotbx.pdb.input(lines=pdb_str.split("\n"), source_info=None)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,13 +2,6 @@ import pytest
 
 from cctbx.xray import structure
 
-# Hack to clear the cache between tests
-@pytest.fixture(autouse=True)
-def clear_cache():
-    from pydiscamb import DiscambWrapper
-
-    DiscambWrapper._DiscambWrapper__clear_cache()
-
 
 @pytest.fixture
 def random_structure() -> structure:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 import pytest
-
 from cctbx.xray import structure
 
 
@@ -77,8 +76,8 @@ def large_random_structure() -> structure:
 
 @pytest.fixture
 def tyrosine() -> structure:
-    import mmtbx.model
     import iotbx.pdb
+    import mmtbx.model
     from libtbx.utils import null_out
 
     pdb_str = """
@@ -120,10 +119,10 @@ ATOM     24  HH  TYR A   4       4.712   5.804   4.444  1.00 30.00           H
 
 @pytest.fixture
 def lysozyme() -> structure:
-    import mmtbx.model
     import iotbx.pdb
-    from libtbx.utils import null_out
+    import mmtbx.model
     import requests
+    from libtbx.utils import null_out
 
     data = requests.get("https://files.rcsb.org/view/7ULY.pdb")
     pdb_str = data.content.decode("utf-8")

--- a/tests/test_atom_assignment.py
+++ b/tests/test_atom_assignment.py
@@ -1,7 +1,8 @@
 import pytest
 from cctbx.eltbx.chemical_elements import proper_caps_list as elements
 
-from pydiscamb import DiscambWrapper, FCalcMethod
+from pydiscamb import FCalcMethod
+from pydiscamb.discamb_wrapper import DiscambWrapper_Uncached as DiscambWrapper
 from pydiscamb.taam_parameters import is_MATTS_installed
 
 

--- a/tests/test_atom_assignment.py
+++ b/tests/test_atom_assignment.py
@@ -1,7 +1,6 @@
 import pytest
 from cctbx.eltbx.chemical_elements import proper_caps_list as elements
-
-from pydiscamb import FCalcMethod, DiscambWrapper
+from pydiscamb import DiscambWrapper, FCalcMethod
 from pydiscamb.taam_parameters import is_MATTS_installed
 
 
@@ -78,6 +77,7 @@ def test_assignment_log_urecognized_structure(tmp_path):
         for i in range(36):
             assert f.readline() == f"{elements()[i]}{i + 1}\n".rjust(8)
 
+
 @pytest.mark.skipif(not is_MATTS_installed(), reason="Must have MATTS installed")
 def test_assignment_log_tyrosine(tyrosine, tmp_path):
     logfile = tmp_path / "assignment.log"
@@ -114,6 +114,7 @@ def test_assignment_log_tyrosine(tyrosine, tmp_path):
         assert f.readline() == '   pdb=" HH  TYR A   4 "    H114    Z pdb=" OH  TYR A   4 " X pdb=" CZ  TYR A   4 "\n'
         # fmt: on
 
+
 @pytest.mark.skipif(not is_MATTS_installed(), reason="Must have MATTS installed")
 def test_assignment_symmetry_wrapping(tmp_path):
     # Download a graphene cif
@@ -133,6 +134,7 @@ def test_assignment_symmetry_wrapping(tmp_path):
     w = DiscambWrapper(xrs, FCalcMethod.TAAM, assignment_info=str(logfile))
     with logfile.open("r") as f:
         assert f.readline() == "Atom type assigned to 2 of 2.\n"
+
 
 @pytest.mark.skipif(not is_MATTS_installed(), reason="Must have MATTS installed")
 def test_assignment_break_when_changing_to_heavy_atom(tmp_path):

--- a/tests/test_atom_assignment.py
+++ b/tests/test_atom_assignment.py
@@ -1,8 +1,7 @@
 import pytest
 from cctbx.eltbx.chemical_elements import proper_caps_list as elements
 
-from pydiscamb import FCalcMethod
-from pydiscamb.discamb_wrapper import DiscambWrapper_Uncached as DiscambWrapper
+from pydiscamb import FCalcMethod, DiscambWrapper
 from pydiscamb.taam_parameters import is_MATTS_installed
 
 

--- a/tests/test_correctness.py
+++ b/tests/test_correctness.py
@@ -1,4 +1,6 @@
 import pydiscamb
+from pydiscamb import FCalcMethod
+from pydiscamb.discamb_wrapper import DiscambWrapper_Uncached as DiscambWrapper
 
 from cctbx.development import random_structure
 from cctbx.sgtbx import space_group_info
@@ -59,7 +61,7 @@ def get_IAM_correctness_score(
     xrs: random_structure.xray_structure, d_min: float = 2
 ) -> float:
     fcalc_cctbx = xrs.structure_factors(algorithm="direct", d_min=d_min).f_calc().data()
-    fcalc_discamb = pydiscamb.calculate_structure_factors_IAM(xrs, d_min)
+    fcalc_discamb = DiscambWrapper(xrs).f_calc(d_min)
 
     fcalc_discamb = flex.complex_double(fcalc_discamb)
     score = compare_structure_factors(fcalc_cctbx, fcalc_discamb)
@@ -96,8 +98,8 @@ def test_lysozyme_high_res(lysozyme):
 @pytest.mark.parametrize(
     "method",
     [
-        pydiscamb.FCalcMethod.IAM,
-        pydiscamb.FCalcMethod.TAAM,
+        FCalcMethod.IAM,
+        FCalcMethod.TAAM,
     ],
 )
 def test_indices_order(method, tyrosine):
@@ -118,11 +120,11 @@ def test_indices_order(method, tyrosine):
     inds_2 = [inds_1[i] for i in shuffle_inds]
 
     # Calculate fcalc with both sets of indices
-    w1 = pydiscamb.DiscambWrapper(tyrosine, method)
+    w1 = DiscambWrapper(tyrosine, method)
     w1.set_indices(inds_1)
     fc1 = w1.f_calc()
 
-    w2 = pydiscamb.DiscambWrapper(tyrosine, method)
+    w2 = DiscambWrapper(tyrosine, method)
     w2.set_indices(inds_2)
     fc2 = w2.f_calc()
 

--- a/tests/test_correctness.py
+++ b/tests/test_correctness.py
@@ -1,12 +1,10 @@
 import pydiscamb
-from pydiscamb import FCalcMethod, DiscambWrapper
-
-from cctbx.development import random_structure
-from cctbx.sgtbx import space_group_info
-from cctbx.array_family import flex
-from cctbx.eltbx import xray_scattering
-
 import pytest
+from cctbx.array_family import flex
+from cctbx.development import random_structure
+from cctbx.eltbx import xray_scattering
+from cctbx.sgtbx import space_group_info
+from pydiscamb import DiscambWrapper, FCalcMethod
 
 
 def compare_structure_factors(f_calc_a, f_calc_b):

--- a/tests/test_correctness.py
+++ b/tests/test_correctness.py
@@ -1,6 +1,5 @@
 import pydiscamb
-from pydiscamb import FCalcMethod
-from pydiscamb.discamb_wrapper import DiscambWrapper_Uncached as DiscambWrapper
+from pydiscamb import FCalcMethod, DiscambWrapper
 
 from cctbx.development import random_structure
 from cctbx.sgtbx import space_group_info

--- a/tests/test_direct_sf_calculation.py
+++ b/tests/test_direct_sf_calculation.py
@@ -1,5 +1,4 @@
 import pydiscamb
-
 import pytest
 
 

--- a/tests/test_f_calc_gradients.py
+++ b/tests/test_f_calc_gradients.py
@@ -1,6 +1,5 @@
 import pytest
-
-from pydiscamb import FCalcMethod, DiscambWrapper
+from pydiscamb import DiscambWrapper, FCalcMethod
 
 
 @pytest.mark.parametrize("method", [FCalcMethod.IAM, FCalcMethod.TAAM])

--- a/tests/test_f_calc_gradients.py
+++ b/tests/test_f_calc_gradients.py
@@ -1,7 +1,6 @@
 import pytest
 
-from pydiscamb import FCalcMethod
-from pydiscamb.discamb_wrapper import DiscambWrapper_Uncached as DiscambWrapper
+from pydiscamb import FCalcMethod, DiscambWrapper
 
 
 @pytest.mark.parametrize("method", [FCalcMethod.IAM, FCalcMethod.TAAM])

--- a/tests/test_f_calc_gradients.py
+++ b/tests/test_f_calc_gradients.py
@@ -1,6 +1,7 @@
 import pytest
 
-from pydiscamb import DiscambWrapper, FCalcMethod
+from pydiscamb import FCalcMethod
+from pydiscamb.discamb_wrapper import DiscambWrapper_Uncached as DiscambWrapper
 
 
 @pytest.mark.parametrize("method", [FCalcMethod.IAM, FCalcMethod.TAAM])

--- a/tests/test_get_table.py
+++ b/tests/test_get_table.py
@@ -1,5 +1,4 @@
 import pytest
-
 from pydiscamb import get_table
 
 

--- a/tests/test_taam.py
+++ b/tests/test_taam.py
@@ -1,6 +1,7 @@
 import pytest
 
-from pydiscamb import DiscambWrapper, FCalcMethod
+from pydiscamb import FCalcMethod
+from pydiscamb.discamb_wrapper import DiscambWrapper_Uncached as DiscambWrapper
 from pydiscamb.taam_parameters import is_MATTS_installed, get_TAAM_databanks
 
 def test_init(tyrosine):

--- a/tests/test_taam.py
+++ b/tests/test_taam.py
@@ -1,8 +1,8 @@
 import pytest
 
-from pydiscamb import FCalcMethod
-from pydiscamb.discamb_wrapper import DiscambWrapper_Uncached as DiscambWrapper
+from pydiscamb import FCalcMethod, DiscambWrapper
 from pydiscamb.taam_parameters import is_MATTS_installed, get_TAAM_databanks
+
 
 def test_init(tyrosine):
     w = DiscambWrapper(tyrosine, FCalcMethod.TAAM)
@@ -101,6 +101,7 @@ def test_invalid_bank(tyrosine):
             model="matts",
             bank_path="non-existent bank file",
         )
+
 
 @pytest.mark.skipif(not is_MATTS_installed(), reason="Must have MATTS installed")
 def test_switching_banks(tyrosine):

--- a/tests/test_taam.py
+++ b/tests/test_taam.py
@@ -1,7 +1,6 @@
 import pytest
-
-from pydiscamb import FCalcMethod, DiscambWrapper
-from pydiscamb.taam_parameters import is_MATTS_installed, get_TAAM_databanks
+from pydiscamb import DiscambWrapper, FCalcMethod
+from pydiscamb.taam_parameters import get_TAAM_databanks, is_MATTS_installed
 
 
 def test_init(tyrosine):

--- a/tests/test_target_gradients.py
+++ b/tests/test_target_gradients.py
@@ -4,7 +4,7 @@ import numpy as np
 from cctbx.array_family import flex
 import mmtbx.f_model
 
-from pydiscamb import DiscambWrapper
+from pydiscamb.discamb_wrapper import DiscambWrapper_Uncached as DiscambWrapper
 from pydiscamb._cpp_module import TargetDerivatives
 
 

--- a/tests/test_target_gradients.py
+++ b/tests/test_target_gradients.py
@@ -1,9 +1,7 @@
-import pytest
-import numpy as np
-
-from cctbx.array_family import flex
 import mmtbx.f_model
-
+import numpy as np
+import pytest
+from cctbx.array_family import flex
 from pydiscamb import DiscambWrapper
 from pydiscamb._cpp_module import TargetDerivatives
 

--- a/tests/test_target_gradients.py
+++ b/tests/test_target_gradients.py
@@ -4,7 +4,7 @@ import numpy as np
 from cctbx.array_family import flex
 import mmtbx.f_model
 
-from pydiscamb.discamb_wrapper import DiscambWrapper_Uncached as DiscambWrapper
+from pydiscamb import DiscambWrapper
 from pydiscamb._cpp_module import TargetDerivatives
 
 

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -1,8 +1,7 @@
-from cctbx.array_family import flex
-from cctbx import miller
 import pytest
-
-from pydiscamb import FCalcMethod, DiscambWrapper
+from cctbx import miller
+from cctbx.array_family import flex
+from pydiscamb import DiscambWrapper, FCalcMethod
 from pydiscamb.discamb_wrapper import DiscambWrapperCached
 
 
@@ -122,8 +121,8 @@ class TestUpdateStructure:
 class TestCache:
     def test_simple(self, random_structure):
         DiscambWrapperCached.__cache = {}
-        # Show that, even when objects are created in an unavailable scope, 
-        # that the object is still cached
+        # Show that, even when objects are created in an unavailable scope,
+        # the object is still cached
 
         def init_wrapper():
             w = DiscambWrapperCached(random_structure)

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -2,7 +2,9 @@ from cctbx.array_family import flex
 from cctbx import miller
 import pytest
 
-from pydiscamb import DiscambWrapper, FCalcMethod
+from pydiscamb import FCalcMethod
+from pydiscamb.discamb_wrapper import DiscambWrapper_Uncached as DiscambWrapper
+from pydiscamb.discamb_wrapper import DiscambWrapper as DiscambWrapper_Cached
 
 
 def test_init(random_structure):
@@ -61,16 +63,17 @@ def test_cache(lysozyme):
     from time import perf_counter
 
     start = perf_counter()
-    w1 = DiscambWrapper(lysozyme, FCalcMethod.TAAM)
+    w1 = DiscambWrapper_Cached(lysozyme, FCalcMethod.TAAM)
     w1_time = perf_counter() - start
 
     start = perf_counter()
-    w2 = DiscambWrapper(lysozyme, FCalcMethod.TAAM)
+    w2 = DiscambWrapper_Cached(lysozyme, FCalcMethod.TAAM)
     w2_time = perf_counter() - start
 
     assert w1_time / w2_time > 10, "Atom assignment should be at least 10x slower than cache lookup"
 
     assert all(a == b for a, b in zip(w1.f_calc(2), w2.f_calc(2)))
+    assert w1 is w2
 
 
 @pytest.mark.parametrize(["p", "dp"], [(False, True), (True, False), (True, True)])

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -120,7 +120,30 @@ class TestUpdateStructure:
 
 
 class TestCache:
-    def test_simple(self, lysozyme):
+    def test_simple(self, random_structure):
+        DiscambWrapperCached.__cache = {}
+        # Show that, even when objects are created in an unavailable scope, 
+        # that the object is still cached
+
+        def init_wrapper():
+            w = DiscambWrapperCached(random_structure)
+            res = id(w)
+            del w
+            return res
+
+        with pytest.raises(NameError):
+            # Wrapper is not in this scope
+            print(w)
+
+        wrapper_ids = [
+            init_wrapper(),
+            init_wrapper(),
+            init_wrapper(),
+            init_wrapper(),
+        ]
+        assert all(wi == init_wrapper() for wi in wrapper_ids)
+
+    def test_timesave(self, lysozyme):
         DiscambWrapperCached.__cache = {}
         from time import perf_counter
 


### PR DESCRIPTION
Adds pydiscamb.discamb_wrapper.DiscambWrapperCached for caching, and removes it from DiscambWrapper.
Caching now also needs identical unit cells.

Refactors some tests, and adds a few new ones regarding caching.
Update documentation with update_structure and caching.