### PR TITLE
Assignment info in runtime

### DIFF
--- a/pydiscamb/discamb_wrapper.py
+++ b/pydiscamb/discamb_wrapper.py
@@ -62,6 +62,12 @@ class DiscambWrapper(PythonInterface):
             "bank_path": get_default_databank(),
             "table": table_alias("xray" if table is None else table),
             "electron_scattering": table == "electron",
+            "assignment_info": str(Path(__file__).parent / "tmp" / "assignment.log")
+            # TODO memory management: delete wrapper object gracefully
+            # Also then delete the log file then
+            # Maybe have some unique filename for this? having always the same will cause problems
+            # Then read the produced file after super().__init__
+
         }
         if method == FCalcMethod.IAM:
             out.update({"electron_scattering": False})

--- a/tests/test_atom_assignment.py
+++ b/tests/test_atom_assignment.py
@@ -209,3 +209,14 @@ def test_assignment_break_when_changing_to_heavy_atom(tmp_path):
         assert f.readline() == "    H1        H101    Z C1 X Au1\n"
         assert f.readline() == "    H2        H101    Z C1 X Au1\n"
         assert f.readline() == "    H3        H101    Z C1 X Au1\n"
+
+
+def test_assignment_member():
+    xrs = _get_single_element_structure("Na")
+    xrs = xrs.concatenate(_get_single_element_structure("Au"))
+    w = DiscambWrapper(xrs, FCalcMethod.TAAM)
+    assert hasattr(w, "atom_type_assignment")
+    assert isinstance(w.atom_type_assignment, dict)
+    assert len(w.atom_type_assignment) == 2
+    assert w.atom_type_assignment["Na1"] == ("Na000", "")
+    assert w.atom_type_assignment["Au1"] == ("", "")

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -142,6 +142,7 @@ class TestCache:
         ]
         assert all(wi == init_wrapper() for wi in wrapper_ids)
 
+    @pytest.mark.xfail(reason="Assignment is very fast now. Update test to larger structure")
     def test_timesave(self, lysozyme):
         DiscambWrapperCached.__cache = {}
         from time import perf_counter

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -142,7 +142,9 @@ class TestCache:
         ]
         assert all(wi == init_wrapper() for wi in wrapper_ids)
 
-    @pytest.mark.xfail(reason="Assignment is very fast now. Update test to larger structure")
+    @pytest.mark.xfail(
+        reason="Assignment is very fast now. Update test to larger structure"
+    )
     def test_timesave(self, lysozyme):
         DiscambWrapperCached.__cache = {}
         from time import perf_counter


### PR DESCRIPTION
Closes #23 
Adds an `atom_type_assignment` dict to the wrapper, with atom labels as keys and a tuple of assignment and local coordinate system definition as value. 

This will always be present for TAAM, and relies on temporary files if the "assignment_csv" kwarg is not set.
In DiSCaMB, the assigner object is quite difficult to access, as there are multiple layers of private class behaviour in between. Therefore, a csv file with the assignment is made by the assigner, and later read in python.

Waiting on update in discamb to enable this feature