### PR TITLE
Assignment csv cleanup

### DIFF
--- a/pydiscamb/discamb_wrapper.py
+++ b/pydiscamb/discamb_wrapper.py
@@ -66,18 +66,15 @@ class DiscambWrapper(PythonInterface):
             self.atom_type_assignment = {
                 atom.label: ("", "") for atom in xrs.scatterers()
             }
-        if kwargs.get("assignment_csv") is not None:
-            assignment_csv = Path(calculator_params["assignment csv"])
-            assert assignment_csv.exists(), str(assignment_csv)
-            with assignment_csv.open("r") as f:
-                self.atom_type_assignment = {
-                    label: (atomtype, lcs)
-                    for label, atomtype, lcs in csv.reader(f, delimiter=";")
-                }
-        if (
-            kwargs.get("assignment_csv") is None
-            and calculator_params["model"] == "taam"
-        ):
+            return
+        assignment_csv = Path(calculator_params["assignment csv"])
+        assert assignment_csv.exists(), str(assignment_csv)
+        with assignment_csv.open("r") as f:
+            self.atom_type_assignment = {
+                label: (atomtype, lcs)
+                for label, atomtype, lcs in csv.reader(f, delimiter=";")
+            }
+        if kwargs.get("assignment_csv") is None:
             os.remove(calculator_params["assignment csv"])
 
     @staticmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydiscamb"
-version = "0.1.4"
+version = "0.1.5"
 description="A python wrapper for DiSCaMB"
 readme = "README.md"
 authors = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -133,7 +133,7 @@ def lysozyme() -> structure:
     xrs.scattering_type_registry(table="electron")
     return xrs
 
-
+@pytest.fixture
 def ethane() -> structure:
     from cctbx import crystal, xray
     from cctbx.array_family import flex

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -132,3 +132,40 @@ def lysozyme() -> structure:
     xrs = model.get_xray_structure()
     xrs.scattering_type_registry(table="electron")
     return xrs
+
+
+def ethane() -> structure:
+    from cctbx import crystal, xray
+    from cctbx.array_family import flex
+
+    crystal_symmetry = crystal.symmetry(
+        unit_cell=(10, 10, 10, 90, 90, 90), space_group_symbol="P1"
+    )
+    coords = [
+        (-0.7560, 0.0000, 0.0000),
+        (0.7560, 0.0000, 0.0000),
+        (-1.1404, 0.6586, 0.7845),
+        (-1.1404, 0.3501, -0.9626),
+        (-1.1405, -1.0087, 0.1781),
+        (1.1404, -0.3501, 0.9626),
+        (1.1405, 1.0087, -0.1781),
+        (1.1404, -0.6586, -0.7845),
+    ]
+    sites = [crystal_symmetry.unit_cell().fractionalize(coord) for coord in coords]
+
+    scatterers = flex.xray_scatterer(
+        [
+            xray.scatterer("C1", site=sites[0]),
+            xray.scatterer("C2", site=sites[1]),
+            xray.scatterer("H1", site=sites[2]),
+            xray.scatterer("H2", site=sites[3]),
+            xray.scatterer("H3", site=sites[4]),
+            xray.scatterer("H4", site=sites[5]),
+            xray.scatterer("H5", site=sites[6]),
+            xray.scatterer("H6", site=sites[7]),
+        ]
+    )
+
+    xrs = xray.structure(crystal_symmetry=crystal_symmetry, scatterers=scatterers)
+    xrs.scattering_type_registry(table="it1992")
+    return xrs

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -133,6 +133,7 @@ def lysozyme() -> structure:
     xrs.scattering_type_registry(table="electron")
     return xrs
 
+
 @pytest.fixture
 def ethane() -> structure:
     from cctbx import crystal, xray

--- a/tests/test_taam.py
+++ b/tests/test_taam.py
@@ -35,7 +35,7 @@ def test_f_calc_approx_IAM(tyrosine, table, expected_R):
 def test_from_parameters(tyrosine):
     wrapper = DiscambWrapper(
         tyrosine,
-        model="taam",
+        FCalcMethod.TAAM,
         unit_cell_charge=1000,
         scale=True,
     )
@@ -46,7 +46,7 @@ def test_from_parameters(tyrosine):
 def test_logging(tyrosine, tmp_path):
     wrapper = DiscambWrapper(
         tyrosine,
-        model="matts",
+        FCalcMethod.TAAM,
         assignment_info=str(tmp_path / "assignment.txt"),
         parameters_info=str(tmp_path / "parameters.log"),
         multipole_cif=str(tmp_path / "structure.cif"),
@@ -61,13 +61,13 @@ def test_logging(tyrosine, tmp_path):
 def test_unit_cell_charge_scaling(tyrosine):
     w1 = DiscambWrapper(
         tyrosine,
-        model="matts",
+        FCalcMethod.TAAM,
         unit_cell_charge=-1000,
         scale=True,
     )
     w2 = DiscambWrapper(
         tyrosine,
-        model="matts",
+        FCalcMethod.TAAM,
         unit_cell_charge=1000,
         scale=True,
     )
@@ -77,13 +77,13 @@ def test_unit_cell_charge_scaling(tyrosine):
 def test_unit_cell_charge_scaling_off(tyrosine):
     w1 = DiscambWrapper(
         tyrosine,
-        model="matts",
+        FCalcMethod.TAAM,
         unit_cell_charge=1000,
         scale=False,
     )
     w2 = DiscambWrapper(
         tyrosine,
-        model="matts",
+        FCalcMethod.TAAM,
         unit_cell_charge=0,
         scale=False,
     )
@@ -97,7 +97,7 @@ def test_invalid_bank(tyrosine):
     ):
         w = DiscambWrapper(
             tyrosine,
-            model="matts",
+            FCalcMethod.TAAM,
             bank_path="non-existent bank file",
         )
 
@@ -109,6 +109,6 @@ def test_switching_banks(tyrosine):
     for bank in banks:
         w = DiscambWrapper(
             tyrosine,
-            model="matts",
+            FCalcMethod.TAAM,
             bank_path=bank,
         )


### PR DESCRIPTION
Use tempfile for creating the temporary csv file for atom type assignment. Delete when done.
Also expands tests for the "atom_type_assignment" dict member