### PR TITLE
Fix default databank file handle issue

### DIFF
--- a/pydiscamb/discamb_wrapper/fcalc_method.py
+++ b/pydiscamb/discamb_wrapper/fcalc_method.py
@@ -12,7 +12,8 @@ if TYPE_CHECKING:
 
 
 def _get_tmp_assignment_filename() -> str:
-    _, out = tempfile.mkstemp(".csv", "pyDiSCaMB-atom-assignment")
+    fd, out = tempfile.mkstemp(".csv", "pyDiSCaMB-atom-assignment")
+    os.close(fd)
     return out
 
 

--- a/pydiscamb/taam_parameters.py
+++ b/pydiscamb/taam_parameters.py
@@ -1,20 +1,22 @@
 from pathlib import Path
 from typing import List
 
+_DEFAULT_TAAM_DATABANK: str = None
+_TAAM_ROOT: Path = None
+
 
 def get_TAAM_root() -> Path:
-    # Check if editable
-    project_root = Path(__file__).parent.parent
-    # Assume the existance of a couple files in the project
-    # means that we are in editable
-    if (
-        (project_root / "CMakeLists.txt").exists()
-        and (project_root / "pyproject.toml").exists()
-        and (project_root / "README.md").exists()
-        and (project_root / ".gitignore").exists()
-    ):
-        return project_root / "data"
-    return Path(__file__).parent / "data"
+    global _TAAM_ROOT
+    if _TAAM_ROOT is None:
+        # Check if editable
+        project_root = Path(__file__).parent.parent
+        readme = project_root / "README.md"
+        if readme.exists() and readme.read_text()[:11] == "# pydiscamb":
+            _TAAM_ROOT = project_root / "data"
+        else:
+            _TAAM_ROOT = Path(__file__).parent / "data"
+        assert _TAAM_ROOT.exists()
+    return _TAAM_ROOT
 
 
 def get_TAAM_databanks() -> List[str]:
@@ -34,10 +36,13 @@ def is_MATTS_installed() -> bool:
 
 
 def get_default_databank() -> str:
-    banks = get_TAAM_databanks()
-    search = "MATTS" if is_MATTS_installed() else "default"
-    for bank in banks:
-        if search in bank:
-            return bank
-    # Failsafe
-    return bank
+    global _DEFAULT_TAAM_DATABANK
+    if _DEFAULT_TAAM_DATABANK is None:
+        banks = get_TAAM_databanks()
+        search = "MATTS" if is_MATTS_installed() else "default"
+        for bank in banks:
+            if search in bank:
+                _DEFAULT_TAAM_DATABANK = bank
+                break
+        assert Path(_DEFAULT_TAAM_DATABANK).exists()
+    return _DEFAULT_TAAM_DATABANK

--- a/tests/_open_many_cached_wrappers.py
+++ b/tests/_open_many_cached_wrappers.py
@@ -1,0 +1,17 @@
+## Test script that will open 1000 cached wrapper objects
+# Import modules
+from pydiscamb.discamb_wrapper import DiscambWrapperCached, FCalcMethod
+from cctbx import crystal, xray
+from cctbx.array_family import flex
+
+# Define xrs
+xrs = xray.structure(
+    crystal_symmetry=crystal.symmetry(
+        unit_cell=(10, 10, 10, 90, 90, 90),
+        space_group_symbol="P1",
+    ),
+    scatterers=flex.xray_scatterer([xray.scatterer("C1", site=(0, 0, 0))]),
+)
+# Get a bunch of wrapper objects
+for _ in range(1000):
+    DiscambWrapperCached(xrs, FCalcMethod.TAAM)

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -356,7 +356,7 @@ class TestCache:
         process = subprocess.Popen(
             [sys.executable, str(script)], preexec_fn=limit_nofiles
         )
-        assert process.wait() == 0
+        assert process.wait() == 0, process.stdout
 
 
 class TestFromFile:

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -334,6 +334,30 @@ class TestCache:
             .data()
         )
 
+    @pytest.mark.skipif(
+        condition=sys.platform != "linux",
+        reason="Needs the resource package, only available on unix",
+    )
+    def test_no_too_many_open_files_error(self):
+        # There was an issue with the default TAAM parameters
+        # requiring opening the parameters file too many times.
+        # We test this by limiting the number of open file handles in another process,
+        # and then instantiating a bunch of wrapper objects
+        import sys
+        import resource
+        import subprocess
+        from pathlib import Path
+
+        def limit_nofiles():
+            resource.setrlimit(resource.RLIMIT_NOFILE, (256, 256))
+
+        # Get location of test script
+        script = Path(__file__).with_name("_open_many_cached_wrappers.py")
+        process = subprocess.Popen(
+            [sys.executable, str(script)], preexec_fn=limit_nofiles
+        )
+        assert process.wait() == 0
+
 
 class TestFromFile:
     def test_pdb(self, tmp_path, random_structure):


### PR DESCRIPTION
Fixes a bug where the repeated instantiation of the wrapper caused many file handles to be open. Locally I have a limit of over a billion handles, so this was never an issue before